### PR TITLE
Fix sharkjack.sh

### DIFF
--- a/sharkjack.sh
+++ b/sharkjack.sh
@@ -72,7 +72,7 @@ function locate_interface_to_shark() {
   printf "\n%s" 'Waiting for a Shark Jack to be connected..'
   while [[ -z $IFACE ]]; do
     printf "%s" .
-    IFACE=$(ip route show to match 172.16.24.1 2>/dev/null| grep -i 172.16.24.1 | cut -d ' ' -f3 | grep -v 172.16.24.1)
+    IFACE=$(ip route show to match 172.16.24.1 2>/dev/null| grep -i 172.16.24.1 | cut -d ' ' -f3)
     sleep 1
   done
   echo -e "\n"


### PR DESCRIPTION
Fix shark jack interface not getting detected. Grepping the ip and invert grepping (grep -v) the same ip cannot return anything (unless -A is set to greater than 1), thus $IFACE is always empty.